### PR TITLE
Listing slots are bookable and only show if they're available to book

### DIFF
--- a/app/controllers/bookings_controller.rb
+++ b/app/controllers/bookings_controller.rb
@@ -15,7 +15,10 @@ class BookingsController < ApplicationController
 
   def create
     @booking = Booking.new
-    @booking.listing_slot = ListingSlot.find(params[:listing_slot_id])
+    @listingslot = ListingSlot.find(params[:listing_slot_id])
+    @listingslot.booked = true
+    @listingslot.save!
+    @booking.listing_slot = @listingslot
     # listing_slot_id is being stored in two places, once from selection and once from params - need to fix
     @booking.user = User.find_by(email: current_user.email)
 

--- a/app/controllers/listing_slots_controller.rb
+++ b/app/controllers/listing_slots_controller.rb
@@ -1,5 +1,6 @@
 class ListingSlotsController < ApplicationController
   def index
+    @listing_slots = ListingSlot.all
   end
 
   def new

--- a/app/views/listings/show.html.erb
+++ b/app/views/listings/show.html.erb
@@ -7,10 +7,12 @@
 
   <h3>Available Slots for <%= @listing.title %></h3>
   <% @listing.listing_slots.each do |slot| %>
-    <% timeslot = "#{slot.start_time} - #{slot.end_time}" %>
-    <% @slot = slot %>
-    <%= link_to timeslot, new_listing_listing_slot_booking_path(@listing, @slot, @user) %>
-    <br>
+    <% if slot.booked != true %>
+      <% timeslot = "#{slot.start_time} - #{slot.end_time}" %>
+      <% @slot = slot %>
+      <%= link_to timeslot, new_listing_listing_slot_booking_path(@listing, @slot, @user) %>
+      <br>
+    <% end %>
   <% end %>
   <p>--------</p>
   <%= link_to "Back to see all tours", listings_path%> <br>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,10 +3,12 @@ Rails.application.routes.draw do
   root to: "listings#index"
 
   resources :listings do
-    resources :listing_slots, only: [:new, :create] do
-      resources :bookings, only: [:new, :create]
+    resources :listing_slots, only: %i[new create] do
+      resources :bookings, only: %i[new create]
     end
   end
 
-  resources :bookings, only: [:index, :show, :destroy]
+  resources :listing_slots, only: [:index]
+
+  resources :bookings, only: %i[index show destroy]
 end

--- a/db/migrate/20230824032505_add_booked_to_listing_slots.rb
+++ b/db/migrate/20230824032505_add_booked_to_listing_slots.rb
@@ -1,0 +1,5 @@
+class AddBookedToListingSlots < ActiveRecord::Migration[7.0]
+  def change
+    add_column :listing_slots, :booked, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_22_062805) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_24_032505) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -29,6 +29,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_22_062805) do
     t.date "end_time"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "booked"
     t.index ["listing_id"], name: "index_listing_slots_on_listing_id"
   end
 


### PR DESCRIPTION
# Changes Made
A migration was made to add the column "booked" to listing slots. This is a boolean value which is initially nil, and which is set to true when a booking for that slot is made.
This is then used to filter slots and only slow slots where booked != true (so that only available slots can be booked)